### PR TITLE
[finishes 169541609] chore(v1) set up node and testing

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": ["@babel/preset-env"],
+    "plugins": [["@babel/transform-runtime"]]
+  }
+  

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  extends: [
+    'airbnb-base',
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+  },
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+  },
+  rules: {
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+.nyc_output
+coverage 
+.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "stable"
+before_script:
+  - npm install
+script:
+  - npm test
+after_script:
+  - npm run coverage

--- a/coveralls.yml
+++ b/coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: HedJ7Gtol8JSjB055jAKvj66gIA0QuYDQ

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --fix ./",
-    "test": "nyc --reporter=html --reporter=text mocha --timeout 100000 --require @babel/register \"./{,!(node_modules)/**/}Server/test/*.test.js\" --exit",
+    "test": "nyc --reporter=html --reporter=text mocha --timeout 100000 --require @babel/register \"./{,!(node_modules)/**/}server/test/*.test.js\" --exit",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "start": "nodemon --exec babel-node Server/index.js",
     "build": "babel Server --out-dir build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --fix ./",
-    "test": "nyc --reporter=html --reporter=text mocha --timeout 100000 --require @babel/register \"./{,!(node_modules)/**/}Server/test/**/*.test.js\" --exit",
+    "test": "nyc --reporter=html --reporter=text mocha --timeout 100000 --require @babel/register \"./{,!(node_modules)/**/}Server/test/*.test.js\" --exit",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "start": "nodemon --exec babel-node Server/index.js",
     "build": "babel Server --out-dir build",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "mydiary-adc",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "eslint --fix ./",
+    "test": "nyc --reporter=html --reporter=text mocha --timeout 100000 --require @babel/register \"./{,!(node_modules)/**/}Server/test/**/*.test.js\" --exit",
+    "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+    "start": "nodemon --exec babel-node Server/index.js",
+    "build": "babel Server --out-dir build",
+    "serve": "node build/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/blaise82/MyDiary-ADC.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/blaise82/MyDiary-ADC/issues"
+  },
+  "homepage": "https://github.com/blaise82/MyDiary-ADC#readme",
+  "dependencies": {
+    "@babel/polyfill": "^7.6.0",
+    "@babel/runtime": "^7.6.3",
+    "bcrypt": "^3.0.6",
+    "body-parser": "^1.19.0",
+    "chai": "^4.2.0",
+    "chai-http": "^4.3.0",
+    "dotenv": "^8.2.0",
+    "express": "^4.17.1",
+    "joi": "^14.3.1",
+    "jsonwebtoken": "^8.5.1",
+    "make-runnable": "^1.3.6",
+    "mocha": "^6.2.2",
+    "moment": "^2.24.0",
+    "pg": "^7.12.1",
+    "uuid": "^3.3.3"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
+    "@babel/node": "^7.6.3",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/preset-env": "^7.6.3",
+    "coveralls": "^3.0.7",
+    "eslint": "^6.6.0",
+    "eslint-config-airbnb-base": "^14.0.0",
+    "eslint-plugin-import": "^2.18.2",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nodemon": "^1.19.4",
+    "nyc": "^14.1.1"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import dotenv from 'dotenv';
+dotenv.config();
+const bodyParser = require('body-parser');
+
+const app = express();
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+app.use(express.static('./ui'));
+
+app.get('/', (req, res) => res.send('Server Is On'));
+app.use((req, res) => {
+  res.status(400).send({
+    status: 400,
+    error: 'Bad Request',
+  });
+});
+if (!module.parent) {
+  app.listen(process.env.PORT || 8080);
+}
+
+
+export default app;

--- a/server/test/v1.test.js
+++ b/server/test/v1.test.js
@@ -1,8 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { describe, it } from 'mocha';
-import jwt from 'jsonwebtoken';
-import app from '../../index';
+import app from '../index';
 
 chai.use(chaiHttp);
 describe('Server Config Check', () => {
@@ -26,4 +25,3 @@ describe('Server Config Check', () => {
       });
   });
 });
-

--- a/server/test/v1/v1.test.js
+++ b/server/test/v1/v1.test.js
@@ -1,0 +1,29 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { describe, it } from 'mocha';
+import jwt from 'jsonwebtoken';
+import app from '../../index';
+
+chai.use(chaiHttp);
+describe('Server Config Check', () => {
+  it('Should return Server Is On', (done) => {
+    chai
+      .request(app)
+      .get('/')
+      .end((err, res) => {
+        expect(res);
+        done();
+      });
+  });
+  it('Should return Bad Request(400 wrong route)', (done) => {
+    chai
+      .request(app)
+      .get('/wrong')
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+});
+


### PR DESCRIPTION
#### What does this PR do?
set up node v1

#### Description of Task to be completed?
- a setup node v1
`
 "@babel/polyfill": "^7.6.0",
 "@babel/runtime": "^7.6.3",
 "bcrypt": "^3.0.6",
 "body-parser": "^1.19.0",
 "@babel/cli": "^7.6.4",
 "@babel/core": "^7.6.4",
 "@babel/node": "^7.6.3",
 "@babel/plugin-transform-runtime": "^7.6.2",
 "@babel/preset-env": "^7.6.3",
`
#### How should this be manually tested?
- clone this repo 
- run `npm install`
- navigate to ch-set-up-node-169541609 (`checkout  ch-set-up-node-169541609 `)
- open the index page on your browser 
