### PR TITLE
[finishes 169546396] feature(v1) view all entries API

### DIFF
--- a/server/controllers/entry.js
+++ b/server/controllers/entry.js
@@ -15,13 +15,25 @@ class Entry {
       modifiedDate: moment().format('LLLL'),
     };
     entryModel.entries.push(newEntry);
-    
     return res.status(201).json({
       status: 201,
       message: 'entry successfully created',
       data: {
         newEntry,
       },
+    });
+  }
+
+  static getAll(req, res) {
+    const myEntries = [];
+    for (let index = 0; index < entryModel.entries.length; index += 1) {
+      if (entryModel.entries[index].createdBy === req.tokenData.email) {
+        myEntries.push(entryModel.entries[index]);
+      }
+    }
+    return res.status(200).json({
+      status: 200,
+      data: { myEntries },
     });
   }
 }

--- a/server/routes/entry.js
+++ b/server/routes/entry.js
@@ -5,4 +5,6 @@ import checkNewEntry from '../middleware/checkNewEntry';
 
 const router = express.Router();
 router.post('/entries', [checkToken, checkNewEntry], Entry.create);
+router.get('/entries', checkToken, Entry.getAll);
+
 export default router;

--- a/server/test/v1.test.js
+++ b/server/test/v1.test.js
@@ -375,4 +375,59 @@ describe('Diary Entry test', () => {
         });
     });
   });
+  describe('/Get /api/v1/entries (Getting All entry)', () => {
+    it('should not allow user  get all entry without a token (authenticity)', (done) => {
+      chai
+        .request(app)
+        .get('/api/v1/entries')
+        .end((err, res) => {
+          expect(res).to.have.status(403);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('should not allow user  get all entry with a fake token (wrong secret key use)', (done) => {
+      const token = jwt
+        .sign({ email: 'example@gmail.com' }, 'fake secret key')
+        .toString();
+      chai
+        .request(app)
+        .get('/api/v1/entries')
+        .set('auth', token)
+        .end((err, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('should not allow user  get all entry with a fake token (wrong email)', (done) => {
+      const token = jwt
+        .sign({ email: 'fakeEmail@gmail.com' }, process.env.SECRET)
+        .toString();
+      chai
+        .request(app)
+        .get('/api/v1/entries')
+        .set('auth', token)
+        .end((err, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+
+    it('should get all entry of a given user', (done) => {
+      const token = jwt
+        .sign({ email: 'example@gmail.com' }, process.env.SECRET)
+        .toString();
+      chai
+        .request(app)
+        .get('/api/v1/entries')
+        .set('auth', token)
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body.data).to.be.a('object');
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
user view all entries api v1

#### Description of Task to be completed?
- create view all entries  controller

#### How should this be manually tested?
- clone this repo
- navigate toft-view-all-entries-api-v1-169546396(`git checkout ft-view-all-entries-api-v1-169546396`)
- run npm install
- run npm start (to start the server)
![Capture get all entries v2](https://user-images.githubusercontent.com/52036624/68404905-e73d7a00-0187-11ea-80d1-cdfa2bd04949.PNG)
