### PR TITLE
[finishes 169547390] feature(v2) add entry API

### DIFF
--- a/server/controllers/v2/entry.js
+++ b/server/controllers/v2/entry.js
@@ -1,0 +1,36 @@
+import uuid from 'uuid';
+import moment from 'moment';
+import conn from '../../database/connect';
+
+class Entry {
+  static async add(req, res) {
+    const { title, description } = req.body;
+    const createdBy = req.tokenData.email;
+    const text = `INSERT INTO
+      entries(id, title, description, created_by,created_date, modified_date)
+      VALUES($1, $2, $3, $4, $5, $6)`;
+    const newEntry = [
+      uuid.v4(),
+      title,
+      description,
+      createdBy,
+      moment().format('LLLL'),
+      moment().format('LLLL'),
+    ];
+    try {
+      await conn.query(text, newEntry);
+      return res.status(201).json({
+        status: 201,
+        message: 'entry successfully created',
+        data: {
+          newEntry,
+        },
+      });
+    } catch (error) {
+      return res.status(422).json({
+        error: error.message,
+      });
+    }
+  }
+}
+export default Entry;

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import v1userRoute from './routes/v1/user';
 import v1entryRoute from './routes/v1/entry';
 import v2usersRoute from './routes/v2/user';
+import v2entryRoute from './routes/v2/entry';
 
 dotenv.config();
 const bodyParser = require('body-parser');
@@ -17,6 +18,7 @@ app.use('/api/v1/auth', v1userRoute);
 app.use('/api/v1', v1entryRoute);
 
 app.use('/api/v2/auth', v2usersRoute);
+app.use('/api/v2', v2entryRoute);
 app.get('/', (req, res) => res.send('Server Is On'));
 app.use((req, res) => {
   res.status(400).send({

--- a/server/middleware/v2/authenticate.js
+++ b/server/middleware/v2/authenticate.js
@@ -1,0 +1,42 @@
+import jwt from 'jsonwebtoken';
+import conn from '../../database/connect';
+
+async function checkToken(req, res, next) {
+  const token = await req.headers.auth;
+  let InUserEmail;
+  if (typeof token !== 'undefined') {
+    jwt.verify(token, process.env.SECRET, async (err, result) => {
+      if (err) {
+        if (err.name === 'TokenExpiredError') {
+          return res.status(403).send({
+            status: 403,
+            error: 'TokenExpired',
+          });
+        }
+      } else {
+        InUserEmail = result.email;
+        const verified = jwt.verify(token, process.env.SECRET);
+        req.tokenData = verified;
+      }
+    });
+
+    const findAllQuery = 'SELECT * FROM users WHERE email=$1';
+    try {
+      const { rowCount } = await conn.query(findAllQuery, [InUserEmail]);
+      if (!rowCount) {
+        return res.status(401).send({
+          status: 401,
+          error: 'not authorized to do the task',
+        });
+      }next();
+    } catch (e) {
+      return res.status(400).send(e.message);
+    }
+  } else {
+    res.status(403).send({
+      status: 403,
+      error: 'not authorized to do the task(forbidden)',
+    });
+  }
+}
+export default checkToken;

--- a/server/routes/v2/entry.js
+++ b/server/routes/v2/entry.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import Entry from '../../controllers/v2/entry';
+import checkToken from '../../middleware/v2/authenticate';
+import checkNewEntry from '../../middleware/v1/checkNewEntry';
+
+const router = express.Router();
+
+router.post('/entries', checkToken, checkNewEntry, Entry.add);
+export default router;

--- a/server/test/v2/v2.test.js
+++ b/server/test/v2/v2.test.js
@@ -226,3 +226,115 @@ describe('User Tests', () => {
     });
   });
 });
+
+describe('Diary Entry test', () => {
+  describe('/POST /api/v2/entries (creation of a diary entry)', () => {
+    it('Should NOT Allow user to create an entry without title data', (done) => {
+      const token = jwt
+        .sign({ email: 'email@gmail.com' }, process.env.SECRET)
+        .toString();
+      const entryTestData1 = {
+        description: 'my description',
+      };
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .set('auth', token)
+        .send(entryTestData1)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('Should NOT Allow user to create an entry without description data', (done) => {
+      const token = jwt
+        .sign({ email: 'email@gmail.com' }, process.env.SECRET)
+        .toString();
+      const entryTestData2 = {
+        title: 'my title',
+      };
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .set('auth', token)
+        .send(entryTestData2)
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('Should NOT Allow user to create an entry with invalid no data', (done) => {
+      const token = jwt
+        .sign({ email: 'email@gmail.com' }, process.env.SECRET)
+        .toString();
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .set('auth', token)
+        .send({})
+        .end((err, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('Should NOT Allow user to create a new diary entry without a login token (logged in user)', (done) => {
+      const entryTestData4 = {
+        title: 'diary',
+        description: 'Updated description',
+      };
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .send(entryTestData4)
+        .end((err, res) => {
+          expect(res).to.have.status(403);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+    it('Should NOT Allow user to create a new diary entry with token fake token(fake email)', (done) => {
+      const entryTestData5 = {
+        title: 'Updated title',
+        description: 'Updated description',
+      };
+      const token = jwt
+        .sign({ email: 'invalid@gmail.com' }, process.env.SECRET)
+        .toString();
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .set('auth', token)
+        .send(entryTestData5)
+        .end((err, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('error');
+          done();
+        });
+    });
+
+    it('Should Allow user to  create an new diary entry', (done) => {
+      const entryTestData = {
+        title: 'new title',
+        description: 'hi i am testing a new entry',
+      };
+
+      const token = jwt
+        .sign({ email: 'email@gmail.com' }, process.env.SECRET)
+        .toString();
+      chai
+        .request(app)
+        .post('/api/v2/entries')
+        .set('auth', token)
+        .send(entryTestData)
+        .end((err, res) => {
+          expect(res).to.have.status(201);
+          expect(res.body.data).to.be.a('object');
+          expect(res.body).to.have.property('message');
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
user add entry v2

#### Description of Task to be completed?
- create add entry  function in the entry controller

#### How should this be manually tested?
- clone this repo
- navigate to ft-add-entry-api-v2-169547390 (`git checkout fft-add-entry-api-v2-169547390`)
- run npm install
- run npm start (to start the server)
![add entry v2](https://user-images.githubusercontent.com/52036624/68467180-6a111400-021e-11ea-96af-f49e416bc972.PNG)
